### PR TITLE
feat: Add links to README and use README for Docker Hub description

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,3 +29,4 @@ jobs:
           context: .
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/alpine-pdf-tools:latest
+          description: ./README.md

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository contains the files to build a Docker image with Alpine Linux and the PDF tools qpdf and Ghostscript.
 
+## Links
+
+- **GitHub Repository:** <https://github.com/kazuyakuza/alpine-pdf-tools>
+- **Docker Hub Image:** <https://hub.docker.com/repository/docker/kazuyakuza/alpine-pdf-tools>
+
 ## About
 
 This Docker image provides a lightweight environment for working with PDF files. It includes:


### PR DESCRIPTION
This commit includes the following:

- Added links to the GitHub repository and Docker Hub image in the README.
- Updated the GitHub Action workflow to use the README.md file for the Docker Hub image description.