### PR TITLE
feat: Set Docker Hub description using metadata-action label

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,7 +35,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-          description: file=./README.md
+          labels: |
+            org.opencontainers.image.description=Alpine Linux based Docker image with qpdf and Ghostscript for PDF manipulation.
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
This commit updates the GitHub Action workflow to set the `org.opencontainers.image.description` label within the `docker/metadata-action`. This label is used to set the description for the Docker image on Docker Hub.