### PR TITLE
Implement dynamic versioning for Docker image builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,6 +19,28 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+    strategy:
+      matrix:
+        combination: ${{ fromJson(steps.read_compatibility.outputs.json).combinations }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Read compatibility list
+        id: read_compatibility
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const compatibilityList = JSON.parse(fs.readFileSync('./compatibility-list.json', 'utf8'));
+            core.setOutput('json', JSON.stringify(compatibilityList));
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -31,10 +53,14 @@ jobs:
           flavor: |
             latest=true
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}-node{{matrix.combination.nodejs}}-qpdf{{matrix.combination.qpdf}}-gs{{matrix.combination.ghostscript}}
+            type=semver,pattern={{major}}.{{minor}}-node{{matrix.combination.nodejs}}-qpdf{{matrix.combination.qpdf}}-gs{{matrix.combination.ghostscript}}
             type=sha
+          labels: |
+            org.opencontainers.image.description=Alpine Linux based Docker image with qpdf and Ghostscript for PDF manipulation. Supports multiple Node.js versions.
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -43,11 +69,29 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build_args.outputs.args }}
+
+      - name: Generate build arguments
+        id: build_args
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let args = [];
+            if ('${{ matrix.combination.nodejs }}' !== 'latest') {
+              args.push(`NODE_VERSION=${{ matrix.combination.nodejs }}`);
+            }
+            if ('${{ matrix.combination.qpdf }}' !== 'latest') {
+              args.push(`QPDF_VERSION=${{ matrix.combination.qpdf }}`);
+            }
+            if ('${{ matrix.combination.ghostscript }}' !== 'latest') {
+              args.push(`GHOSTSCRIPT_VERSION=${{ matrix.combination.ghostscript }}`);
+            }
+            core.setOutput('args', args.join('\\n'));
 
       - name: Update Docker Hub Image Description
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: kazuyakuza/alpine-pdf-tools
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/alpine-pdf-tools
           short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,12 +7,11 @@ on:
       - main
 
 jobs:
-  build-and-push:
+  read-compatibility:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
-    strategy:
-      matrix:
-        combination: ${{ fromJson(steps.read_compatibility.outputs.json).combinations }}
+    outputs:
+      matrix: ${{ steps.read_compatibility.outputs.json }}  # Pass to next job
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -25,6 +24,17 @@ jobs:
             const fs = require('fs');
             const compatibilityList = JSON.parse(fs.readFileSync('./compatibility-list.json', 'utf8'));
             core.setOutput('json', JSON.stringify(compatibilityList));
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    needs: read-compatibility  # Wait for previous job
+    strategy:
+      matrix:
+        combination: ${{ fromJson(needs.read-compatibility.outputs.matrix).combinations }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -52,6 +62,23 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Generate build arguments
+        id: build_args
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let args = [];
+            if ('${{ matrix.combination.nodejs }}' !== 'latest') {
+              args.push(`--build-arg NODE_VERSION=${{ matrix.combination.nodejs }}`);
+            }
+            if ('${{ matrix.combination.qpdf }}' !== 'latest') {
+              args.push(`--build-arg QPDF_VERSION=${{ matrix.combination.qpdf }}`);
+            }
+            if ('${{ matrix.combination.ghostscript }}' !== 'latest') {
+              args.push(`--build-arg GHOSTSCRIPT_VERSION=${{ matrix.combination.ghostscript }}`);
+            }
+            core.setOutput('args', args.join(' '));
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -60,23 +87,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ steps.build_args.outputs.args }}
-
-      - name: Generate build arguments
-        id: build_args
-        uses: actions/github-script@v6
-        with:
-          script: |
-            let args = [];
-            if ('${{ matrix.combination.nodejs }}' !== 'latest') {
-              args.push(`NODE_VERSION=${{ matrix.combination.nodejs }}`);
-            }
-            if ('${{ matrix.combination.qpdf }}' !== 'latest') {
-              args.push(`QPDF_VERSION=${{ matrix.combination.qpdf }}`);
-            }
-            if ('${{ matrix.combination.ghostscript }}' !== 'latest') {
-              args.push(`GHOSTSCRIPT_VERSION=${{ matrix.combination.ghostscript }}`);
-            }
-            core.setOutput('args', args.join('\\n'));
 
       - name: Update Docker Hub Image Description
         uses: peter-evans/dockerhub-description@v4

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,19 +10,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
     strategy:
       matrix:
         combination: ${{ fromJson(steps.read_compatibility.outputs.json).combinations }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test-docker-image.yml
+++ b/.github/workflows/test-docker-image.yml
@@ -6,9 +6,39 @@ on:
 jobs:
   test-build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        combination: ${{ fromJson(steps.read_compatibility.outputs.json).combinations }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Read compatibility list
+        id: read_compatibility
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const compatibilityList = JSON.parse(fs.readFileSync('./compatibility-list.json', 'utf8'));
+            core.setOutput('json', JSON.stringify(compatibilityList));
+
+      - name: Generate build arguments
+        id: build_args
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let args = [];
+            if ('${{ matrix.combination.nodejs }}' !== 'latest') {
+              args.push(`NODE_VERSION=${{ matrix.combination.nodejs }}`);
+            }
+            if ('${{ matrix.combination.qpdf }}' !== 'latest') {
+              args.push(`QPDF_VERSION=${{ matrix.combination.qpdf }}`);
+            }
+            if ('${{ matrix.combination.ghostscript }}' !== 'latest') {
+              args.push(`GHOSTSCRIPT_VERSION=${{ matrix.combination.ghostscript }}`);
+            }
+            core.setOutput('args', args.join('\\n'));
+
       - name: Build Docker image
-        run: docker build -t alpine-pdf-tools .
+        run: |
+          docker build ${{ steps.build_args.outputs.args }} -t alpine-pdf-tools:test .

--- a/.github/workflows/test-docker-image.yml
+++ b/.github/workflows/test-docker-image.yml
@@ -46,7 +46,7 @@ jobs:
             if ('${{ matrix.combination.ghostscript }}' !== 'latest') {
               args.push(`--build-arg GHOSTSCRIPT_VERSION=${{ matrix.combination.ghostscript }}`);
             }
-            core.setOutput('args', args.join(' '));  # Space-separated list, not \n
+            core.setOutput('args', args.join(' '));
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/test-docker-image.yml
+++ b/.github/workflows/test-docker-image.yml
@@ -38,15 +38,15 @@ jobs:
           script: |
             let args = [];
             if ('${{ matrix.combination.nodejs }}' !== 'latest') {
-              args.push(`NODE_VERSION=${{ matrix.combination.nodejs }}`);
+              args.push(`--build-arg NODE_VERSION=${{ matrix.combination.nodejs }}`);
             }
             if ('${{ matrix.combination.qpdf }}' !== 'latest') {
-              args.push(`QPDF_VERSION=${{ matrix.combination.qpdf }}`);
+              args.push(`--build-arg QPDF_VERSION=${{ matrix.combination.qpdf }}`);
             }
             if ('${{ matrix.combination.ghostscript }}' !== 'latest') {
-              args.push(`GHOSTSCRIPT_VERSION=${{ matrix.combination.ghostscript }}`);
+              args.push(`--build-arg GHOSTSCRIPT_VERSION=${{ matrix.combination.ghostscript }}`);
             }
-            core.setOutput('args', args.join('\\n'));
+            core.setOutput('args', args.join(' '));  # Space-separated list, not \n
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/test-docker-image.yml
+++ b/.github/workflows/test-docker-image.yml
@@ -4,11 +4,10 @@ on:
   pull_request:
 
 jobs:
-  test-build:
+  read-compatibility:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        combination: ${{ fromJson(steps.read_compatibility.outputs.json).combinations }}
+    outputs:
+      matrix: ${{ steps.read_compatibility.outputs.json }}  # Pass to next job
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -21,6 +20,16 @@ jobs:
             const fs = require('fs');
             const compatibilityList = JSON.parse(fs.readFileSync('./compatibility-list.json', 'utf8'));
             core.setOutput('json', JSON.stringify(compatibilityList));
+
+  test-build:
+    runs-on: ubuntu-latest
+    needs: read-compatibility  # Wait for previous job
+    strategy:
+      matrix:
+        combination: ${{ fromJson(needs.read-compatibility.outputs.matrix).combinations }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Generate build arguments
         id: build_args

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *~
 .idea/
 .vscode/
+credentials.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
+ARG NODE_VERSION=18
+ARG QPDF_VERSION=11.10.1
+ARG GHOSTSCRIPT_VERSION=10.0.0
+
 FROM alpine:latest
 
-RUN apk add --no-cache qpdf ghostscript
+RUN apk add --no-cache qpdf=${QPDF_VERSION} ghostscript=${GHOSTSCRIPT_VERSION} nodejs=${NODE_VERSION}
 
 CMD ["gs", "--version"]
 CMD ["qpdf", "--version"]
+CMD ["node", "--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-ARG NODE_VERSION=22
-ARG QPDF_VERSION=11.10.1
-ARG GHOSTSCRIPT_VERSION=10.04.0
+ARG QPDF_VERSION
+ARG GHOSTSCRIPT_VERSION
+ARG NODE_VERSION
 
 FROM alpine:latest
 
-RUN apk add --no-cache qpdf=${QPDF_VERSION} ghostscript=${GHOSTSCRIPT_VERSION} nodejs=${NODE_VERSION}
+RUN apk add --no-cache \
+    qpdf${QPDF_VERSION:+=$QPDF_VERSION} \
+    ghostscript${GHOSTSCRIPT_VERSION:+=$GHOSTSCRIPT_VERSION} \
+    nodejs${NODE_VERSION:+=$NODE_VERSION}
 
 CMD ["gs", "--version"]
 CMD ["qpdf", "--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG GHOSTSCRIPT_VERSION=10.04.0
 
 FROM alpine:latest
 
-RUN apk add --no-cache qpdf@${QPDF_VERSION} ghostscript@${GHOSTSCRIPT_VERSION} nodejs@${NODE_VERSION}
+RUN apk add --no-cache qpdf=${QPDF_VERSION} ghostscript=${GHOSTSCRIPT_VERSION} nodejs=${NODE_VERSION}
 
 CMD ["gs", "--version"]
 CMD ["qpdf", "--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM alpine:latest
 
 RUN apk add --no-cache qpdf ghostscript
 
-CMD ["ghostscript", "--version"]
+CMD ["gs", "--version"]
 CMD ["qpdf", "--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-ARG NODE_VERSION=18
+ARG NODE_VERSION=22
 ARG QPDF_VERSION=11.10.1
-ARG GHOSTSCRIPT_VERSION=10.0.0
+ARG GHOSTSCRIPT_VERSION=10.04.0
 
 FROM alpine:latest
 
-RUN apk add --no-cache qpdf=${QPDF_VERSION} ghostscript=${GHOSTSCRIPT_VERSION} nodejs=${NODE_VERSION}
+RUN apk add --no-cache qpdf@${QPDF_VERSION} ghostscript@${GHOSTSCRIPT_VERSION} nodejs@${NODE_VERSION}
 
 CMD ["gs", "--version"]
 CMD ["qpdf", "--version"]

--- a/compatibility-list.json
+++ b/compatibility-list.json
@@ -1,0 +1,31 @@
+{
+  "combinations": [
+    {
+      "nodejs": "18",
+      "qpdf": "11.10.1",
+      "ghostscript": "10.0.0"
+    },
+    {
+      "nodejs": "20",
+      "qpdf": "11.10.1",
+      "ghostscript": "10.0.0"
+    },
+    {
+      "nodejs": "21",
+      "qpdf": "11.10.1",
+      "ghostscript": "10.0.0"
+    },
+    {
+      "nodejs": "21",
+      "qpdf": "11.10.1",
+      "ghostscript": "10.3.0",
+      "comment": "While you could try to use 'latest', it's not recommended for reproducibility. Alpine Linux packages are versioned, so 'latest' won't work directly with apk. It's better to specify concrete versions."
+    },
+    {
+      "nodejs": "latest",
+      "qpdf": "latest",
+      "ghostscript": "latest",
+      "comment": "Testing 'latest' keyword for all dependencies."
+    }
+  ]
+}

--- a/compatibility-list.json
+++ b/compatibility-list.json
@@ -1,9 +1,9 @@
 {
   "combinations": [
     {
-      "nodejs": "21",
+      "nodejs": "22",
       "qpdf": "11.10.1",
-      "ghostscript": "10.3.0"
+      "ghostscript": "10.04.0"
     },
     {
       "nodejs": "latest",

--- a/compatibility-list.json
+++ b/compatibility-list.json
@@ -1,25 +1,9 @@
 {
   "combinations": [
     {
-      "nodejs": "18",
-      "qpdf": "11.10.1",
-      "ghostscript": "10.0.0"
-    },
-    {
-      "nodejs": "20",
-      "qpdf": "11.10.1",
-      "ghostscript": "10.0.0"
-    },
-    {
       "nodejs": "21",
       "qpdf": "11.10.1",
-      "ghostscript": "10.0.0"
-    },
-    {
-      "nodejs": "21",
-      "qpdf": "11.10.1",
-      "ghostscript": "10.3.0",
-      "comment": "While you could try to use 'latest', it's not recommended for reproducibility. Alpine Linux packages are versioned, so 'latest' won't work directly with apk. It's better to specify concrete versions."
+      "ghostscript": "10.3.0"
     },
     {
       "nodejs": "latest",

--- a/compatibility-list.json
+++ b/compatibility-list.json
@@ -1,6 +1,11 @@
 {
   "combinations": [
     {
+      "nodejs": "20.3.1",
+      "qpdf": "11.10.1",
+      "ghostscript": "10.04.0"
+    },
+    {
       "nodejs": "22",
       "qpdf": "11.10.1",
       "ghostscript": "10.04.0"
@@ -8,8 +13,7 @@
     {
       "nodejs": "latest",
       "qpdf": "latest",
-      "ghostscript": "latest",
-      "comment": "Testing 'latest' keyword for all dependencies."
+      "ghostscript": "latest"
     }
   ]
 }


### PR DESCRIPTION
This pull request implements dynamic versioning for the Docker image builds, allowing the use of 'latest' for Node.js, qpdf, and Ghostscript versions in compatibility-list.json. It also updates the GitHub Action workflows.